### PR TITLE
Add Alpha Release v0.1.0 of OneAgent SDK for Go

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021 Dynatrace LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,106 @@
-# OneAgent-SDK-for-Go
+# Dynatrace OneAgent SDK for Go
+
+OneAgent SDK for Go has to be used together with OneAgent injected. Otherwise, the dummy implementation of OneAgent SDK will be used.
+The current implementation of OneAgent SDK for Go is made with a single purpose: providing access to the Trace ID and Span ID information of the PurePath node.
+This information can then be used, for example, to provide additional context in log messages.
+
+## Table of Contents
+
+* [Package contents](#package-contents)
+* [Requirements](#requirements)
+* [Integration](#integration)
+  * [Troubleshooting](#troubleshooting)
+* [API Concepts](#api-concepts)
+  * [OneAgentSDK object](#oneagentsdk-object)
+  * [Trace Context](#trace-context)
+* [Help & Support](#help--support)
+* [Release notes](#release-notes)
+
+## Package contents
+
+* `examples`: contains sample application, which demonstrates the usage of the SDK. See readme inside the examples directory for more details.
+* `LICENSE`: license under which the whole SDK and sample applications are published.
+
+## Requirements
+
+* Deep monitoring by Dynatrace OneAgent must be successfully activated.
+
+|OneAgent SDK for Go  |Minimum OneAgent version |Support status |
+|:--------------------|:------------------------|:--------------|
+|0.1.x                |1.233                    |Not supported  |
+
+## Integration
+
+Using this module should not cause any errors if OneAgent is not present (e.g. in testing) since the stub implementation of OneAgent SDK for Go will be used.
+
+### Troubleshooting
+
+If the SDK can not connect to OneAgent, verify that a matching version of OneAgent is used. Check if OneAgent Go log file contains the following log message: `OneAgent SDK has been successfully resolved`.
+
+## API Concepts
+
+Common concepts of the Dynatrace OneAgent SDK are explained in the [Dynatrace OneAgent SDK repository](https://github.com/Dynatrace/OneAgent-SDK).
+
+### OneAgentSDK object
+
+The first step is to acquire an instance of the OneAgent SDK API by calling `sdk.CreateInstance()`.
+
+```go
+import "github.com/Dynatrace/OneAgent-SDK-for-Go/sdk"
+...
+oneagentsdk := sdk.CreateInstance()
+```
+
+### Trace Context
+
+The obtained OneAgent SDK API instance provides the `GetTraceContextInfo()` method, which returns a `TraceContextInfo` object that provides the Trace ID and Span ID of the current PurePath node.
+`TraceContextInfo.IsValid()` may be used to verify that the Trace ID and Span ID are both valid (non-zero).
+Trace ID and Span ID information is not intended for tagging and context-propagation scenarios and primarily designed for log-enrichment use cases.
+
+```go
+...
+traceContext := oneagentsdk.GetTraceContextInfo()
+traceId := traceContext.getTraceId()
+spanId := traceContext.getSpanId()
+```
+
+Trace ID and Span ID values may be invalid in the following cases:
+* OneAgent is not present
+* OneAgent does not support the SDK version (check the [required version](#requirements))
+* There is no active Dynatrace PurePath context
+
+## Help & Support
+
+**Support policy**
+
+Dynatrace OneAgent SDK for Go has alpha status. The features are currently being tested by Dynatrace and subject to change.
+
+For a detailed support policy see [Dynatrace OneAgent SDK help](https://github.com/Dynatrace/OneAgent-SDK#help).
+
+### Get Help
+
+* Ask a question in the [product forums](https://answers.dynatrace.com/spaces/482/view.html)
+* Read the [product documentation](https://www.dynatrace.com/support/help/)
+
+### Open a [GitHub issue](https://github.com/Dynatrace/OneAgent-SDK-for-Go/issues) to
+
+* Report minor defects, minor items or typos
+* Ask for improvements or changes in the SDK API
+* Ask any questions related to the community effort
+
+SLAs don't apply for GitHub tickets.
+
+### Customers can open a ticket on the [Dynatrace support portal](https://support.dynatrace.com/supportportal/) to
+
+* Get support from the Dynatrace technical support engineering team
+* Manage and resolve product related technical issues
+
+SLAs apply according to the customer's support level.
+
+## Release Notes
+
+see also [Releases](https://github.com/Dynatrace/OneAgent-SDK-for-Go/releases)
+
+|Version|Description                                 |
+|:------|:-------------------------------------------|
+|0.1.0  |Initial Alpha Release                       |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# Sample applications for OneAgent SDK for Go
+
+Sample applications showing how to use Dynatrace OneAgent SDK for Go.
+
+## Contents
+
+* `trace_context`: Shows usage of the SDK to get Trace ID and Span ID information of the current PurePath node
+
+## Prepare running sample applications
+
+* Ensure Dynatrace OneAgent is installed. If not see our [free Trial](https://www.dynatrace.com/trial/)
+* Ensure you have [the Go toolchain](https://golang.org "golang") installed
+* Clone this repository
+* Execute `go build` in the sample folder
+
+## TraceContext sample application
+
+This sample shows how to get Trace ID and Span ID information of the current PurePath node.
+Valid Trace ID and Span ID can only be obtained if `GetTraceContextInfo` is executed in context of an active Dynatrace PurePath.
+As an example a simple HTTP server is used, the agent will create a PurePath node which is active while running the HTTP handler.
+Make sure that Go web request monitoring is enabled upon instrumentation of the sample application.
+
+Execute the sample and send an HTTP GET request to `http://localhost:8080`, if everything is configured properly you will get a response with valid Trace and Span IDs of the incoming HTTP request:
+
+```text
+Dynatrace TraceContext of the Incoming HTTP Request:
+TraceId: 2c4a5bcd583ef3fa53ce939dbe0ea136, SpanId: 00f088ac0ba9c2b1, IsValid: true
+```
+
+Trace ID and Span ID values may be invalid in the following cases:
+* OneAgent is not present
+* OneAgent does not support the SDK version (check the [required version](#requirements))
+* There is no active Dynatrace PurePath context

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,5 @@
+module examples
+
+go 1.15
+
+require github.com/Dynatrace/OneAgent-SDK-for-Go v0.1.0

--- a/examples/trace_context/main.go
+++ b/examples/trace_context/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/Dynatrace/OneAgent-SDK-for-Go/sdk"
+)
+
+func main() {
+	// Create OneAgent SDK API instance
+	var oneagentsdk = sdk.CreateInstance()
+
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		// Get TraceContextInfo within the incoming HTTP request
+		// to obtain Trace ID and Span ID of the active Dynatrace PurePath context
+		traceContext := oneagentsdk.GetTraceContextInfo()
+
+		fmt.Fprintf(w, "Dynatrace TraceContext of the Incoming HTTP Request:\n"+
+			"TraceId: %s, SpanId: %s, IsValid: %t",
+			traceContext.GetTraceId(), traceContext.GetSpanId(), traceContext.IsValid())
+	})
+
+	fmt.Println("Starting HTTP server at port 8080...")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Dynatrace/OneAgent-SDK-for-Go
+
+go 1.15

--- a/sdk/internal/stub_sdk.go
+++ b/sdk/internal/stub_sdk.go
@@ -1,0 +1,12 @@
+package internal
+
+import "github.com/Dynatrace/OneAgent-SDK-for-Go/sdk/trace"
+
+type OneAgentStubSDK struct{}
+
+// GetTraceContextInfo returns an invalid TraceContextInfo instance.
+// This method will be replaced by OneAgent to provide the actual values.
+//go:noinline
+func (OneAgentStubSDK) GetTraceContextInfo() trace.TraceContextInfo {
+	return trace.NewTraceContextInfo(trace.InvalidTraceId, trace.InvalidSpanId)
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -1,0 +1,21 @@
+package sdk
+
+import (
+	"github.com/Dynatrace/OneAgent-SDK-for-Go/sdk/internal"
+	"github.com/Dynatrace/OneAgent-SDK-for-Go/sdk/trace"
+)
+
+// OneAgentSDK provides the methods available in the OneAgent SDK for Go.
+type OneAgentSDK interface {
+	// GetTraceContextInfo returns information about the active PurePath node using
+	// the TraceContext model as defined in https://www.w3.org/TR/trace-context.
+	// The returned information is not intended for tagging and context-propagation
+	// scenarios and primarily designed for log-enrichment use cases.
+	GetTraceContextInfo() trace.TraceContextInfo
+}
+
+// CreateInstance returns an instance of the OneAgent SDK.
+//go:noinline
+func CreateInstance() OneAgentSDK {
+	return internal.OneAgentStubSDK{}
+}

--- a/sdk/trace/trace_context_info.go
+++ b/sdk/trace/trace_context_info.go
@@ -1,0 +1,49 @@
+package trace
+
+const (
+	InvalidTraceId = "00000000000000000000000000000000"
+	InvalidSpanId  = "0000000000000000"
+)
+
+// TraceContextInfo provides information about the active PurePath node using
+// the TraceContext (Trace ID, Span ID) model as defined in https://www.w3.org/TR/trace-context.
+// The Span ID represents the active PurePath node.
+// This Trace ID and Span ID information is not intended for tagging and context-propagation
+// scenarios and primarily designed for log-enrichment use cases.
+type TraceContextInfo struct {
+	traceId string
+	spanId  string
+}
+
+// GetTraceId returns Trace ID represented as lower-case hex-encoded string
+// (see: https://tools.ietf.org/html/rfc4648#section-8).
+// Returns an invalid Trace ID in case of:
+// * OneAgent is not present.
+// * OneAgent does not support the SDK version.
+// * There is no active Dynatrace PurePath context.
+func (c *TraceContextInfo) GetTraceId() string {
+	return c.traceId
+}
+
+// GetSpanId returns Span ID represented as lower-case hex-encoded string
+// (see: https://tools.ietf.org/html/rfc4648#section-8).
+// Returns an invalid Span ID in case of:
+// * OneAgent is not present.
+// * OneAgent does not support the SDK version.
+// * There is no active Dynatrace PurePath context.
+func (c *TraceContextInfo) GetSpanId() string {
+	return c.spanId
+}
+
+// IsValid returns true if TraceContextInfo has valid Trace ID and Span ID.
+func (c *TraceContextInfo) IsValid() bool {
+	return c.traceId != InvalidTraceId && c.spanId != InvalidSpanId
+}
+
+// NewTraceContextInfo create an instance of TraceContextInfo with given Trace ID and Span ID.
+func NewTraceContextInfo(traceId, spanId string) TraceContextInfo {
+	return TraceContextInfo{
+		traceId: traceId,
+		spanId:  spanId,
+	}
+}


### PR DESCRIPTION
 * Initial OneAgent SDK API for Go
 * Dummy implementation of the SDK
 * Sample `trace_context` application
 * Documentation