### PR TITLE
Add enrichment metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+bin
+pkg
+

--- a/sdk/internal/stub_sdk.go
+++ b/sdk/internal/stub_sdk.go
@@ -10,3 +10,10 @@ type OneAgentStubSDK struct{}
 func (OneAgentStubSDK) GetTraceContextInfo() trace.TraceContextInfo {
 	return trace.NewTraceContextInfo(trace.InvalidTraceId, trace.InvalidSpanId)
 }
+
+// GetEnrichmentMetadata returns a nil map.
+// This method will be replaced by OneAgent to provide the actual values.
+//go:noinline
+func (OneAgentStubSDK) GetEnrichmentMetadata() map[string]string {
+	return nil
+}

--- a/sdk/native/enrichment.go
+++ b/sdk/native/enrichment.go
@@ -1,0 +1,33 @@
+package native
+
+import (
+	"bufio"
+	"strings"
+)
+
+// GetEnrichmentMetadata returns metadata that can be used to manually enrich
+// log messages when unsupported logging frameworks are used. This function is
+// like OneAgentSDK.GetEnrichmentMetadata, except that it does not require the
+// Go code module be injected (but instead requires use of cgo on Linux only).
+//
+// See also https://www.dynatrace.com/support/help/shortlink/enrich-metrics
+func GetEnrichmentMetadata() (map[string]string, error) {
+	magicFile, err := openEnrichmentMetadataFile()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = magicFile.Close() }()
+
+	result := make(map[string]string)
+	lines := bufio.NewScanner(magicFile)
+	for lines.Scan() {
+		kv := strings.SplitN(lines.Text(), "=", 2)
+		if len(kv) == 2 && kv[0] != "" {
+			result[kv[0]] = kv[1]
+		}
+	}
+	if lines.Err() != nil {
+		return nil, lines.Err()
+	}
+	return result, nil
+}

--- a/sdk/native/enrichment_linux.go
+++ b/sdk/native/enrichment_linux.go
@@ -1,0 +1,50 @@
+package native
+
+/*
+#include <fcntl.h>
+
+const char* const MAGIC_FILE_NAME = "dt_metadata_e617c525669e072eebe3d0f08212e8f2.properties";
+
+// Wrap `open` because cgo doesn't understand variadic functions
+static int myopen(const char *pathname, int flags) {
+	return open(pathname, flags);
+}
+*/
+import "C"
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+// On Linux, os.Open uses the `open` syscall, which OneAgent can't hook directly. Hence, we use a cgo
+// implementation that calls the libc `open` function.
+func openEnrichmentMetadataFile() (*os.File, error) {
+	var f *os.File
+	if fd, errno := C.myopen(C.MAGIC_FILE_NAME, C.O_RDONLY|C.O_CLOEXEC); fd < 0 {
+		return nil, fmt.Errorf("failed to open magic file: %v", errno)
+	} else {
+		f = os.NewFile(uintptr(fd), C.GoString(C.MAGIC_FILE_NAME))
+		defer func() { _ = f.Close() }()
+	}
+
+	buf := new(bytes.Buffer)
+	if strlen, err := buf.ReadFrom(f); err != nil {
+		return nil, err
+	} else if b := buf.Bytes(); b[strlen-1] == '\n' {
+		// Make sure the buffer is null-terminated for use as a C string
+		b[strlen-1] = 0
+	} else {
+		buf.WriteByte(0)
+	}
+
+	cbuf := (*C.char)(unsafe.Pointer(&buf.Bytes()[0]))
+	if fd, errno := C.myopen(cbuf, C.O_RDONLY|C.O_CLOEXEC); fd < 0 {
+		return nil, fmt.Errorf("failed to open magic file: %v", errno)
+	} else {
+		buf.Truncate(buf.Len() - 1)
+		return os.NewFile(uintptr(fd), buf.String()), nil
+	}
+}

--- a/sdk/native/enrichment_windows.go
+++ b/sdk/native/enrichment_windows.go
@@ -1,0 +1,20 @@
+package native
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+const magicFileName = "dt_metadata_e617c525669e072eebe3d0f08212e8f2.properties"
+
+// On Windows, os.Open (used by ioutil.ReadFile) uses CreateFileW, which is hooked by OneAgent.
+func openEnrichmentMetadataFile() (*os.File, error) {
+	data, err := ioutil.ReadFile(magicFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	path := strings.TrimSuffix(string(data), "\n")
+	return os.Open(path)
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -12,6 +12,11 @@ type OneAgentSDK interface {
 	// The returned information is not intended for tagging and context-propagation
 	// scenarios and primarily designed for log-enrichment use cases.
 	GetTraceContextInfo() trace.TraceContextInfo
+
+	// GetEnrichmentMetadata returns metadata that can be used to manually enrich
+	// log messages when unsupported logging frameworks are used.
+	// Also see https://www.dynatrace.com/support/help/shortlink/enrich-metrics
+	GetEnrichmentMetadata() map[string]string
 }
 
 // CreateInstance returns an instance of the OneAgent SDK.

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -15,7 +15,7 @@ type OneAgentSDK interface {
 
 	// GetEnrichmentMetadata returns metadata that can be used to manually enrich
 	// log messages when unsupported logging frameworks are used.
-	// Also see https://www.dynatrace.com/support/help/shortlink/enrich-metrics
+	// See also https://www.dynatrace.com/support/help/shortlink/enrich-metrics
 	GetEnrichmentMetadata() map[string]string
 }
 


### PR DESCRIPTION
This adds two different implementations for getting log enrichment metadata from OneAgent. One requires the Go code module be injected (but doesn't require use of cgo); the other does not require the Go code module be injected, but requires use of cgo on Linux.

1. I did not add an example for the new functionality, because I don't think it would add any value. Let me know if you want me to add one anyway.
2. We need to improve the documentation with regards to required OneAgent versions. As soon as we have more than one feature, "the SDK" doesn't require a particular OneAgent version, but "feature A" and "feature B" may require different ones.
3. Should all functions be documented in the README as well as the source code? Since documentation will be generated automatically [on pkg.go.dev](https://pkg.go.dev/github.com/Dynatrace/OneAgent-SDK-for-Go) for the module, I suggest we put as much documentation as possible in source code instead of the readme (and link to pkg.go.dev from the latter).

ONE-75361