### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,70 @@
 # Dynatrace OneAgent SDK for Go
 
-OneAgent SDK for Go has to be used together with OneAgent injected. Otherwise, the dummy implementation of OneAgent SDK
-will be used. The current implementation of OneAgent SDK for Go is made with a single purpose: providing access to the
-Trace ID and Span ID information of the PurePath node.
-This information can then be used, for example, to provide additional context in log messages.
+[![Go Reference](https://pkg.go.dev/badge/github.com/Dynatrace/OneAgent-SDK-for-Go.svg)](https://pkg.go.dev/github.com/Dynatrace/OneAgent-SDK-for-Go)
 
-## Table of Contents
+This SDK provides functionality for Go applications to enrich their log messages and OpenTelemetry traces with metadata
+useful in a Dynatrace environment.
 
-* [Package contents](#package-contents)
-* [Requirements](#requirements)
-* [Integration](#integration)
-  * [Troubleshooting](#troubleshooting)
-* [API Concepts](#api-concepts)
-  * [OneAgentSDK object](#oneagentsdk-object)
-  * [Trace Context](#trace-context)
-* [Help & Support](#help--support)
-* [Release notes](#release-notes)
 
 ## Package contents
 
-* `examples`: contains sample application, which demonstrates the usage of the SDK. See readme inside the directory
+* `examples`: contains sample applications, which demonstrate usage of the SDK. See readme inside the directory
   for more details.
 * `LICENSE`: license under which the whole SDK and sample applications are published.
 
+
 ## Requirements
 
-* Deep monitoring by Dynatrace OneAgent must be successfully activated.
+* Some features require the OneAgent Go code module to be injected successfully (i.e. deep monitoring being activated),
+  while other features work without it. OneAgent is required in any case.
 
 | OneAgent SDK for Go | Minimum OneAgent version | Support status |
 |:--------------------|:-------------------------|:---------------|
+| 1.1.0               | 1.245                    | Supported      |
 | 1.0.0               | 1.233                    | Supported      |
 | 0.1.0               | 1.233                    | Not supported  |
 
-## Integration
+### Integration
 
-Using this module should not cause any errors if OneAgent is not present (e.g. in testing) since the stub implementation
-of OneAgent SDK for Go will be used.
+Using the functions in this module without OneAgent present should be perfectly fine. The functions will then return
+invalid values or an error. This may happen in the following cases:
+
+* OneAgent is not present.
+* OneAgent does not support the SDK version (check the [required version](#requirements)).
+* Some other reason specific to a particular function.
 
 ### Troubleshooting
 
-If the SDK can not connect to OneAgent, verify that a matching version of OneAgent is used. Check if OneAgent Go log
-file contains the following log message: `OneAgent SDK has been successfully resolved`.
+If the SDK can not connect to OneAgent, verify that a matching version of OneAgent is used and deep monitoring is
+activated. Check that the OneAgent Go log file contains the following log message:
 
-## API Concepts
-
-Common concepts of the Dynatrace OneAgent SDK are explained in the
-[Dynatrace OneAgent SDK repository](https://github.com/Dynatrace/OneAgent-SDK).
-
-### OneAgentSDK object
-
-The first step is to acquire an instance of the OneAgent SDK API by calling `sdk.CreateInstance()`.
-
-```go
-import "github.com/Dynatrace/OneAgent-SDK-for-Go/sdk"
-...
-oneagentsdk := sdk.CreateInstance()
+```text
+OneAgent SDK has been resolved successfully
 ```
 
-### Trace Context
 
-The obtained OneAgent SDK API instance provides the `GetTraceContextInfo()` method, which returns a `TraceContextInfo`
-object that provides the Trace ID and Span ID of the current PurePath node.
-`TraceContextInfo.IsValid()` may be used to verify that the Trace ID and Span ID are both valid (non-zero).
-Trace ID and Span ID information is not intended for tagging and context-propagation scenarios and primarily designed
-for log-enrichment use cases.
+## Features
 
-```go
-...
-traceContext := oneagentsdk.GetTraceContextInfo()
-traceId := traceContext.getTraceId()
-spanId := traceContext.getSpanId()
-```
+Common API concepts of the Dynatrace OneAgent SDK are explained in the [Dynatrace OneAgent SDK repository][dt-sdk]. An
+overview of features in this SDK will follow, see the [`sdk` package documentation][pkg-sdk] for detailed information.
 
-Trace ID and Span ID values may be invalid in the following cases:
-* OneAgent is not present
-* OneAgent does not support the SDK version (check the [required version](#requirements))
-* There is no active Dynatrace PurePath context
+| Feature                                | SDK Version |
+|:---------------------------------------|:------------|
+| [Enrichment metadata][func-enrichment] | ≥ 1.1.0     |
+| [TraceContext][pkg-tracecontext]       | ≥ 1.0.0     |
+
+[dt-sdk]: https://github.com/Dynatrace/OneAgent-SDK
+[pkg-sdk]: https://pkg.go.dev/github.com/Dynatrace/OneAgent-SDK-for-Go/sdk
+[pkg-tracecontext]: https://pkg.go.dev/github.com/Dynatrace/OneAgent-SDK-for-Go/sdk/trace#TraceContextInfo
+[iface-sdk]: https://pkg.go.dev/github.com/Dynatrace/OneAgent-SDK-for-Go/sdk#OneAgentSDK
+[func-enrichment]: https://pkg.go.dev/github.com/Dynatrace/OneAgent-SDK-for-Go/sdk/native#GetEnrichmentMetadata
+
 
 ## Help & Support
 
 **Support policy**
 
-Dynatrace OneAgent SDK for Go has alpha status. The features are currently being tested by Dynatrace and subject to change.
+Starting with version 1.0.0, Dynatrace OneAgent SDK for Go has GA status. The features are fully supported by Dynatrace.
 
 For a detailed support policy see [Dynatrace OneAgent SDK help](https://github.com/Dynatrace/OneAgent-SDK#help).
 
@@ -105,10 +88,13 @@ SLAs don't apply for GitHub tickets.
 
 SLAs apply according to the customer's support level.
 
+
 ## Release Notes
 
-see also [Releases](https://github.com/Dynatrace/OneAgent-SDK-for-Go/releases)
+See also [GitHub Releases](https://github.com/Dynatrace/OneAgent-SDK-for-Go/releases).
 
 | Version | Description                                |
 |:--------|:-------------------------------------------|
-| 0.1.0   | Initial Alpha Release                      |
+| 1.1.0   | Added support for enrichment metadata      |
+| 1.0.0   | Initial GA release                         |
+| 0.1.0   | Initial Alpha release                      |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Dynatrace OneAgent SDK for Go
 
-OneAgent SDK for Go has to be used together with OneAgent injected. Otherwise, the dummy implementation of OneAgent SDK will be used.
-The current implementation of OneAgent SDK for Go is made with a single purpose: providing access to the Trace ID and Span ID information of the PurePath node.
+OneAgent SDK for Go has to be used together with OneAgent injected. Otherwise, the dummy implementation of OneAgent SDK
+will be used. The current implementation of OneAgent SDK for Go is made with a single purpose: providing access to the
+Trace ID and Span ID information of the PurePath node.
 This information can then be used, for example, to provide additional context in log messages.
 
 ## Table of Contents
@@ -18,29 +19,33 @@ This information can then be used, for example, to provide additional context in
 
 ## Package contents
 
-* `examples`: contains sample application, which demonstrates the usage of the SDK. See readme inside the examples directory for more details.
+* `examples`: contains sample application, which demonstrates the usage of the SDK. See readme inside the directory
+  for more details.
 * `LICENSE`: license under which the whole SDK and sample applications are published.
 
 ## Requirements
 
 * Deep monitoring by Dynatrace OneAgent must be successfully activated.
 
-|OneAgent SDK for Go  |Minimum OneAgent version |Support status |
-|:--------------------|:------------------------|:--------------|
-|1.0.0                |1.233                    |Supported      |
-|0.1.0                |1.233                    |Not supported  |
+| OneAgent SDK for Go | Minimum OneAgent version | Support status |
+|:--------------------|:-------------------------|:---------------|
+| 1.0.0               | 1.233                    | Supported      |
+| 0.1.0               | 1.233                    | Not supported  |
 
 ## Integration
 
-Using this module should not cause any errors if OneAgent is not present (e.g. in testing) since the stub implementation of OneAgent SDK for Go will be used.
+Using this module should not cause any errors if OneAgent is not present (e.g. in testing) since the stub implementation
+of OneAgent SDK for Go will be used.
 
 ### Troubleshooting
 
-If the SDK can not connect to OneAgent, verify that a matching version of OneAgent is used. Check if OneAgent Go log file contains the following log message: `OneAgent SDK has been successfully resolved`.
+If the SDK can not connect to OneAgent, verify that a matching version of OneAgent is used. Check if OneAgent Go log
+file contains the following log message: `OneAgent SDK has been successfully resolved`.
 
 ## API Concepts
 
-Common concepts of the Dynatrace OneAgent SDK are explained in the [Dynatrace OneAgent SDK repository](https://github.com/Dynatrace/OneAgent-SDK).
+Common concepts of the Dynatrace OneAgent SDK are explained in the
+[Dynatrace OneAgent SDK repository](https://github.com/Dynatrace/OneAgent-SDK).
 
 ### OneAgentSDK object
 
@@ -54,9 +59,11 @@ oneagentsdk := sdk.CreateInstance()
 
 ### Trace Context
 
-The obtained OneAgent SDK API instance provides the `GetTraceContextInfo()` method, which returns a `TraceContextInfo` object that provides the Trace ID and Span ID of the current PurePath node.
+The obtained OneAgent SDK API instance provides the `GetTraceContextInfo()` method, which returns a `TraceContextInfo`
+object that provides the Trace ID and Span ID of the current PurePath node.
 `TraceContextInfo.IsValid()` may be used to verify that the Trace ID and Span ID are both valid (non-zero).
-Trace ID and Span ID information is not intended for tagging and context-propagation scenarios and primarily designed for log-enrichment use cases.
+Trace ID and Span ID information is not intended for tagging and context-propagation scenarios and primarily designed
+for log-enrichment use cases.
 
 ```go
 ...
@@ -102,6 +109,6 @@ SLAs apply according to the customer's support level.
 
 see also [Releases](https://github.com/Dynatrace/OneAgent-SDK-for-Go/releases)
 
-|Version|Description                                 |
-|:------|:-------------------------------------------|
-|0.1.0  |Initial Alpha Release                       |
+| Version | Description                                |
+|:--------|:-------------------------------------------|
+| 0.1.0   | Initial Alpha Release                      |

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,8 +8,8 @@ Sample applications showing how to use Dynatrace OneAgent SDK for Go.
 
 ## Prepare running sample applications
 
-* Ensure Dynatrace OneAgent is installed. If not see our [free Trial](https://www.dynatrace.com/trial/)
-* Ensure you have [the Go toolchain](https://golang.org "golang") installed
+* Ensure Dynatrace OneAgent is installed. If not see our [free trial](https://www.dynatrace.com/trial/)
+* Ensure you have the [Go toolchain](https://golang.org "golang") installed
 * Clone this repository
 * Execute `go build` in the sample folder
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,12 +15,13 @@ Sample applications showing how to use Dynatrace OneAgent SDK for Go.
 
 ## TraceContext sample application
 
-This sample shows how to get Trace ID and Span ID information of the current PurePath node.
-Valid Trace ID and Span ID can only be obtained if `GetTraceContextInfo` is executed in context of an active Dynatrace PurePath.
-As an example a simple HTTP server is used, the agent will create a PurePath node which is active while running the HTTP handler.
-Make sure that Go web request monitoring is enabled upon instrumentation of the sample application.
+This sample shows how to get Trace ID and Span ID information of the current PurePath node. Valid Trace ID and Span ID
+can only be obtained if `GetTraceContextInfo` is executed in context of an active Dynatrace PurePath. As an example a
+simple HTTP server is used, the agent will create a PurePath node which is active while running the HTTP handler. Make
+sure that Go web request monitoring is enabled upon instrumentation of the sample application.
 
-Execute the sample and send an HTTP GET request to `http://localhost:8080`, if everything is configured properly you will get a response with valid Trace and Span IDs of the incoming HTTP request:
+Execute the sample and send an HTTP GET request to `http://localhost:8080`, if everything is configured properly you
+will get a response with valid Trace and Span IDs of the incoming HTTP request:
 
 ```text
 Dynatrace TraceContext of the Incoming HTTP Request:

--- a/sdk/internal/stub_sdk.go
+++ b/sdk/internal/stub_sdk.go
@@ -2,17 +2,14 @@ package internal
 
 import "github.com/Dynatrace/OneAgent-SDK-for-Go/sdk/trace"
 
+// The methods of this type will be replaced by OneAgent to provide their actual return values.
 type OneAgentStubSDK struct{}
 
-// GetTraceContextInfo returns an invalid TraceContextInfo instance.
-// This method will be replaced by OneAgent to provide the actual values.
 //go:noinline
 func (OneAgentStubSDK) GetTraceContextInfo() trace.TraceContextInfo {
 	return trace.NewTraceContextInfo(trace.InvalidTraceId, trace.InvalidSpanId)
 }
 
-// GetEnrichmentMetadata returns a nil map.
-// This method will be replaced by OneAgent to provide the actual values.
 //go:noinline
 func (OneAgentStubSDK) GetEnrichmentMetadata() map[string]string {
 	return nil

--- a/sdk/native/doc.go
+++ b/sdk/native/doc.go
@@ -1,0 +1,2 @@
+// Package native contains functionality that does not require the OneAgent Go code module.
+package native

--- a/sdk/native/enrichment.go
+++ b/sdk/native/enrichment.go
@@ -11,6 +11,8 @@ import (
 // Go code module be injected (but instead requires use of cgo on Linux only).
 //
 // See also https://www.dynatrace.com/support/help/shortlink/enrich-metrics
+//
+// Since SDK version 1.1.0 - OneAgent version 1.245
 func GetEnrichmentMetadata() (map[string]string, error) {
 	magicFile, err := openEnrichmentMetadataFile()
 	if err != nil {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -1,3 +1,8 @@
+// Package sdk provides the OneAgentSDK interface, which is the entry point to all OneAgent SDK for Go functionality.
+// See also package sdk/native, which provides functionality that does not require the OneAgent Go code module.
+//
+// The first step in using the SDK is to acquire an instance of the OneAgentSDK interface by using the
+// `CreateInstance` function.
 package sdk
 
 import (
@@ -5,17 +10,24 @@ import (
 	"github.com/Dynatrace/OneAgent-SDK-for-Go/sdk/trace"
 )
 
-// OneAgentSDK provides the methods available in the OneAgent SDK for Go.
+// OneAgentSDK provides the methods available in the OneAgent SDK for Go. All methods are safe for concurrent use
+// from multiple goroutines.
 type OneAgentSDK interface {
-	// GetTraceContextInfo returns information about the active PurePath node using
-	// the TraceContext model as defined in https://www.w3.org/TR/trace-context.
-	// The returned information is not intended for tagging and context-propagation
-	// scenarios and primarily designed for log-enrichment use cases.
+	// GetTraceContextInfo returns information about the active PurePath node using the TraceContext model as defined
+	// in https://www.w3.org/TR/trace-context. The returned information is not intended for tagging or
+	// context propagation scenarios, it is primarily designed for log-enrichment use cases.
+	//
+	// The returned value may be invalid in case there is no active Dynatrace PurePath context.
+	//
+	// Since SDK version 1.0.0 - OneAgent version 1.233
 	GetTraceContextInfo() trace.TraceContextInfo
 
-	// GetEnrichmentMetadata returns metadata that can be used to manually enrich
-	// log messages when unsupported logging frameworks are used.
+	// GetEnrichmentMetadata returns metadata that can be used to manually enrich log messages when unsupported
+	// logging frameworks are used.
+	//
 	// See also https://www.dynatrace.com/support/help/shortlink/enrich-metrics
+	//
+	// Since SDK version 1.1.0 - OneAgent version 1.245
 	GetEnrichmentMetadata() map[string]string
 }
 

--- a/sdk/trace/trace_context_info.go
+++ b/sdk/trace/trace_context_info.go
@@ -5,11 +5,11 @@ const (
 	InvalidSpanId  = "0000000000000000"
 )
 
-// TraceContextInfo provides information about the active PurePath node using
-// the TraceContext (Trace ID, Span ID) model as defined in https://www.w3.org/TR/trace-context.
-// The Span ID represents the active PurePath node.
-// This Trace ID and Span ID information is not intended for tagging and context-propagation
-// scenarios and primarily designed for log-enrichment use cases.
+// TraceContextInfo is the type returned by `OneAgentSDK.GetTraceContextInfo()`. It provides information about the
+// active PurePath node using the TraceContext (Trace ID, Span ID) model as defined in https://www.w3.org/TR/trace-context.
+//
+// The Span ID represents the active PurePath node and is not intended for tagging or context propagation scenarios,
+// it is primarily designed for log-enrichment use cases.
 type TraceContextInfo struct {
 	traceId string
 	spanId  string
@@ -17,20 +17,12 @@ type TraceContextInfo struct {
 
 // GetTraceId returns Trace ID represented as lower-case hex-encoded string
 // (see: https://tools.ietf.org/html/rfc4648#section-8).
-// Returns an invalid Trace ID in case of:
-// * OneAgent is not present.
-// * OneAgent does not support the SDK version.
-// * There is no active Dynatrace PurePath context.
 func (c *TraceContextInfo) GetTraceId() string {
 	return c.traceId
 }
 
 // GetSpanId returns Span ID represented as lower-case hex-encoded string
 // (see: https://tools.ietf.org/html/rfc4648#section-8).
-// Returns an invalid Span ID in case of:
-// * OneAgent is not present.
-// * OneAgent does not support the SDK version.
-// * There is no active Dynatrace PurePath context.
 func (c *TraceContextInfo) GetSpanId() string {
 	return c.spanId
 }
@@ -40,7 +32,7 @@ func (c *TraceContextInfo) IsValid() bool {
 	return c.traceId != InvalidTraceId && c.spanId != InvalidSpanId
 }
 
-// NewTraceContextInfo create an instance of TraceContextInfo with given Trace ID and Span ID.
+// NewTraceContextInfo creates an instance of TraceContextInfo with given Trace ID and Span ID.
 func NewTraceContextInfo(traceId, spanId string) TraceContextInfo {
 	return TraceContextInfo{
 		traceId: traceId,


### PR DESCRIPTION
This moves some of the documentation to the Go source files, so it's available on pkg.go.dev, and removes unnecessary stuff from the repo readme (which is included in the generated documentation on pkg.go.dev).
Also adds the new enrichment metadata feature to the readme.