### PR TITLE
Create workflow to block fixups in PRs

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,9 @@
+name: Git Checks
+on: [pull_request]
+jobs:
+  block-fixup:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
This adds a GitHub workflow that blocks PRs as long as they contain any fixup commits.

See also https://github.com/marketplace/actions/block-fixup-commit-merge